### PR TITLE
v0.7.1 Update copy on results pages, rearrange buttons, responsive titles and error message, refactor assessment logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ MacOS:
 ###NB
 If you change the routes please update the route-order "page_flow" tuple in 'utils/back_function.py' so the back button works correctly 
 + the routes.txt file which shows the route function and paired route
+
+To make changes to question pages there is one partial for all the F/S questions and then the single-question items are less templated so need to be modified directly (dsq/viral.html and short_form/reduction.html)

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -2,6 +2,7 @@ from flask import render_template, session
 import plotly.graph_objects as go
 import json
 import plotly.utils
+
 # screener questions
 # 'fatigue13c', 'remember36c', 'minimum17c', 'unrefreshed19c',
 

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -2,6 +2,8 @@ from flask import render_template, session
 import plotly.graph_objects as go
 import json
 import plotly.utils
+# screener questions
+# 'fatigue13c', 'remember36c', 'minimum17c', 'unrefreshed19c',
 
 def screener_diagnose():
     # we *25 to scale 4pt scale to 100 pt scale

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -62,7 +62,8 @@ def screener_diagnose():
         yaxis_title='Combined Frequency and Severity Scores',
         xaxis_title='Symptom Domains'
     )
-    fig.update_yaxes(range=[0, 100], dtick=25)
+    fig.update_yaxes(range=[0, 100], dtick=25, titlefont=dict(size=15))
+    fig.update_xaxes(tickfont=dict(size=13), titlefont=dict(size=15))
     graphJSON = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
     return render_template("results/graph.html",
                            graphJSON = graphJSON, 

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -1,6 +1,5 @@
 from flask import render_template, session
 import plotly.graph_objects as go
-import pandas as pd
 import json
 import plotly.utils
 

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -1,0 +1,75 @@
+from flask import render_template, session
+import plotly.graph_objects as go
+import pandas as pd
+import json
+import plotly.utils
+
+def screener_diagnose():
+    # we *25 to scale 4pt scale to 100 pt scale
+    fatiguescore = domain_score('fatiguescore')
+    pemscore = domain_score('pemscore')
+    sleepscore = domain_score('sleepscore')
+    cogscore = domain_score('cogscore')
+
+    df = pd.read_csv('MECFS COMPOSITE DATA.csv')
+    responses = [fatiguescore, pemscore, sleepscore, cogscore]
+    iomfatiguecheck = "No"
+    iompemcheck = "No"
+    iomsleepcheck = "No"
+    iomcogcheck = "No"
+    dx_met = False
+
+    if session['fatiguescoref'] >= 2 and session['fatiguescores'] >= 2:
+        iomfatiguecheck = "Yes"
+    if session['minexf'] >= 2 and session['minexs'] >= 2:
+        iompemcheck = "Yes"
+    if session['sleepf'] >= 2 and session['sleeps'] >= 2:
+        iomsleepcheck = "Yes"
+    if session['rememberf'] >= 2 and session['remembers'] >= 2:
+        iomcogcheck = "Yes"
+
+    if iomfatiguecheck == "Yes" or iompemcheck == "Yes" or iomsleepcheck == "Yes" or iomcogcheck == "Yes":
+        screen_message = 'Based on your responses to our screener questions, there is a chance you might have MECFS. <br> Please continue to the next section for a more accurate assessment.'
+        dx_met = True
+    else:
+        screen_message = "Based on your responses to our screener questions, it does not appear you have MECFS."
+
+    composite_scores = responses
+    categories = ['Fatigue', 'Post-exertional malaise', 'Sleep problems',
+                  'Cognitive problems']
+
+    select_list = ['fatigue13c', (session['pemname'] + 'c'),
+                   (session['cogname'] + 'c'), (session['sleepname'] + 'c'), 'dx']
+    df = df[select_list]
+    colors = ['#89889E' if score < 50 else '#56A8A0' for score in composite_scores]
+    
+    # composite f/s score graph
+    fig = go.Figure(
+        data=[
+            go.Bar(y=composite_scores, x=categories, name="Your scores", marker=dict(color=colors))],
+        layout=go.Layout(
+            title=go.layout.Title(text='Your Summary Score', x=0.5),
+            showlegend=True, 
+            legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="right",
+                x=1
+            ),
+            autosize=True
+        )
+    )
+    fig.update_layout(
+        yaxis_title='Combined Frequency and Severity Scores',
+        xaxis_title='Symptom Domains'
+    )
+    fig.update_yaxes(range=[0, 100], dtick=25)
+    graphJSON = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
+    return render_template("results/graph.html",
+                           graphJSON = graphJSON, 
+                           screen_message = screen_message,
+                           dx_met = dx_met)
+
+def domain_score(session_var_string):
+    return 1 if session[session_var_string] == 0 else session[session_var_string] * 25

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -6,12 +6,11 @@ import plotly.utils
 
 def screener_diagnose():
     # we *25 to scale 4pt scale to 100 pt scale
-    fatiguescore = domain_score('fatiguescore')
-    pemscore = domain_score('pemscore')
-    sleepscore = domain_score('sleepscore')
-    cogscore = domain_score('cogscore')
+    fatiguescore = fit_domain_score('fatiguescore')
+    pemscore = fit_domain_score('pemscore')
+    sleepscore = fit_domain_score('sleepscore')
+    cogscore = fit_domain_score('cogscore')
 
-    df = pd.read_csv('MECFS COMPOSITE DATA.csv')
     responses = [fatiguescore, pemscore, sleepscore, cogscore]
     iomfatiguecheck = "No"
     iompemcheck = "No"
@@ -38,7 +37,6 @@ def screener_diagnose():
 
     select_list = ['fatigue13c', (session['pemname'] + 'c'),
                    (session['cogname'] + 'c'), (session['sleepname'] + 'c'), 'dx']
-    df = df[select_list]
     colors = ['#56A8A0' for score in composite_scores]
     
     # composite f/s score graph
@@ -70,5 +68,5 @@ def screener_diagnose():
                            screen_message = screen_message,
                            dx_met = dx_met)
 
-def domain_score(session_var_string):
+def fit_domain_score(session_var_string):
     return 1 if session[session_var_string] == 0 else session[session_var_string] * 25

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -35,8 +35,6 @@ def screener_diagnose():
     categories = ['Fatigue', 'Post-exertional malaise', 'Sleep problems',
                   'Cognitive problems']
 
-    select_list = ['fatigue13c', (session['pemname'] + 'c'),
-                   (session['cogname'] + 'c'), (session['sleepname'] + 'c'), 'dx']
     colors = ['#56A8A0' for score in composite_scores]
     
     # composite f/s score graph

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -28,7 +28,7 @@ def screener_diagnose():
     if session['rememberf'] >= 2 and session['remembers'] >= 2:
         iomcogcheck = "Yes"
 
-    screen_message = 'Your responses to the screener questions are scored below. <br> Scores range from 0 to 100, with higher scores indication more frequent and severe problems.'
+    screen_message = 'Your responses to the screener questions are scored below. <br> Scores range from 0 to 100, with higher scores indicate more frequent and severe problems.'
     if iomfatiguecheck == "Yes" or iompemcheck == "Yes" or iomsleepcheck == "Yes" or iomcogcheck == "Yes":
         dx_met = True
 

--- a/utils/screener_utils.py
+++ b/utils/screener_utils.py
@@ -28,11 +28,9 @@ def screener_diagnose():
     if session['rememberf'] >= 2 and session['remembers'] >= 2:
         iomcogcheck = "Yes"
 
+    screen_message = 'Your responses to the screener questions are scored below. <br> Scores range from 0 to 100, with higher scores indication more frequent and severe problems.'
     if iomfatiguecheck == "Yes" or iompemcheck == "Yes" or iomsleepcheck == "Yes" or iomcogcheck == "Yes":
-        screen_message = 'Based on your responses to our screener questions, there is a chance you might have MECFS. <br> Please continue to the next section for a more accurate assessment.'
         dx_met = True
-    else:
-        screen_message = "Based on your responses to our screener questions, it does not appear you have MECFS."
 
     composite_scores = responses
     categories = ['Fatigue', 'Post-exertional malaise', 'Sleep problems',
@@ -41,7 +39,7 @@ def screener_diagnose():
     select_list = ['fatigue13c', (session['pemname'] + 'c'),
                    (session['cogname'] + 'c'), (session['sleepname'] + 'c'), 'dx']
     df = df[select_list]
-    colors = ['#89889E' if score < 50 else '#56A8A0' for score in composite_scores]
+    colors = ['#56A8A0' for score in composite_scores]
     
     # composite f/s score graph
     fig = go.Figure(

--- a/utils/short_form_utils.py
+++ b/utils/short_form_utils.py
@@ -1,0 +1,191 @@
+from flask import render_template, session
+import numpy as np
+import plotly.graph_objects as go
+import json
+import plotly.utils
+
+def short_form_diagnose():
+    import domainScores as ds
+
+    fatiguescore = (int(session["fatiguescoref"]) + int(session["fatiguescores"])) / 2
+    pemscore = (int(session["minexf"]) + int(session["minexs"]) + int(session['soref']) + int(session['sores'])) / 4
+    sleepscore = (int(session["sleepf"]) + int(session["sleeps"])) / 2
+    cogscore = (int(session["rememberf"]) + int(session["remembers"]) + int(session['attentionf']) +
+                int(session['attentions'])) / 4
+    painscore = (int(session['musclef']) + int(session['muscles'])) / 2
+    gastroscore = (int(session['bloatf']) + int(session['bloats']) + int(session['bowelf']) +
+                   int(session['bowels'])) / 4
+    orthoscore = (int(session['unsteadyf']) + int(session['unsteadys'])) / 2
+    circscore = (int(session['limbsf']) + int(session['limbss']) + int(session['hotf']) + int(session['hots'])) / 4
+    immunescore = (int(session['fluf']) + int(session['flus'])) / 2
+    neuroenscore = (int(session['smellf']) + int(session['smells'])) / 2
+
+    user_scores = [fatiguescore, pemscore, sleepscore, cogscore, painscore, gastroscore, orthoscore, circscore,
+                   immunescore, neuroenscore]
+
+    shortform_items = ['fatigue13c', 'soreness15c', 'minimum17c', 'unrefreshed19c',
+                       'musclepain25c', 'bloating29c', 'remember36c', 'difficulty37c',
+                       'bowel46c', 'unsteady48c', 'limbs56c', 'hot58c', 'flu65c',
+                       'smells66c']
+
+    df = ds.sdf
+
+    mecfs = df[(df['dx'] == 1)]
+    controls = df[(df['dx'] != 1)]
+
+
+    cfsdomains = np.mean(mecfs.iloc[:, 110:120], axis=0)
+
+    # This assesses the IOM Criteria
+    responses = [fatiguescore, pemscore, sleepscore, cogscore]
+    iomfatiguecheck = "No"
+    iomreductioncheck = "No"
+    iompemcheck = "No"
+    iomsleepcheck = "No"
+    iomcogcheck = "No"
+    iomorthocheck = "No"
+
+    if int(session['fatiguescoref']) >= 2 and int(session['fatiguescores']) >= 2:
+        iomfatiguecheck = "Yes"
+    if int(session['reduction']) == 1:
+        iomreductioncheck = "Yes"
+    if (int(session['minexf']) >= 2 and int(session['minexs'] >= 2) or (
+            int(session['soref']) >= 2 and int(session['sores']) >= 2)):
+        iompemcheck = "Yes"
+    if int(session['sleepf']) >= 2 and int(session['sleeps']) >= 2:
+        iomsleepcheck = "Yes"
+    if (int(session['rememberf']) >= 2 and int(session['remembers']) >= 2 ) or (
+            int(session['attentionf']) >= 2 and int(session['attentions']) >= 2):
+        iomcogcheck = "Yes"
+    if int(session['unsteadyf']) >= 2 and int(session['unsteadys']) >= 2:
+        iomorthocheck = "Yes"
+
+    if iomfatiguecheck == "Yes" and iomreductioncheck == "Yes" and iompemcheck == "Yes" and iomsleepcheck == "Yes" and (iomcogcheck == "Yes" or iomorthocheck == "Yes"):
+        iom_msg = "Your responses suggest you meet the IOM Criteria for ME/CFS. To improve the accuracy" \
+                  " of your assessment with more questions continue to the next section."
+        iomdxcheck = "Met"
+
+    else:
+        iom_msg = "Your responses do not meet the IOM Criteria for ME/CFS."
+        iomdxcheck = "Not met"
+
+    # This assesses the Canadian Consensus Criteria, one of the three major case definitions we use
+
+    ccc_dx = False
+
+    if int(session['fatiguescoref']) >= 2 and int(session['fatiguescores']) >= 2:
+        ccc_fatigue = 1
+        ccc_fatiguecheck = "Yes"
+    else:
+        ccc_fatigue = 0
+        ccc_fatiguecheck = "No"
+    if int(session['reduction']) == 1:
+        ccc_reduction = 1
+        ccc_reductioncheck = "Yes"
+    else:
+        ccc_reduction = 0
+        ccc_reductioncheck = "No"
+    if int(session['musclef']) >= 2 and int(session['muscles']) >= 2:
+        ccc_pain = 1
+        ccc_paincheck = "Yes"
+    else:
+        ccc_pain = 0
+        ccc_paincheck = "No"
+    if int(session['sleepf']) >= 2 and int(session['sleeps']) >= 2:
+        ccc_sleep = 1
+        ccc_sleepcheck = "Yes"
+    else:
+        ccc_sleep = 0
+        ccc_sleepcheck = "No"
+    if (int(session['minexf']) >= 2 and int(session['minexs']) >= 2) or (
+            int(session['soref']) >= 2 and int(session['sores']) >= 2):
+        ccc_pem = 1
+        ccc_pemcheck = "Yes"
+    else:
+        ccc_pem = 0
+        ccc_pemcheck = "No"
+    if (int(session['rememberf']) >= 2 and int(session['remembers']) >= 2) or (
+            int(session['attentionf']) >= 2 and int(session['attentions']) >= 2):
+        ccc_cog = 1
+        ccc_cogcheck = "Yes"
+    else:
+        ccc_cog = 0
+        ccc_cogcheck = "No"
+
+    if (int(session['unsteadyf']) >= 2 and int(session['unsteadys']) >= 2) or (
+            int(session['bowelf']) >= 2 and int(session['bowels']) >= 2) or (
+            int(session['bloatf']) >= 2 and int(session['bloats']) >= 2):
+        ccc_auto = 1
+        ccc_autocheck = "Yes"
+    else:
+        ccc_auto = 0
+        ccc_autocheck = "No"
+    if (int(session['limbsf']) >= 2 and int(session['limbss']) >= 2) or (
+            int(session['hotf']) >= 2 and int(session['hots']) >= 2):
+        ccc_neuro = 1
+        ccc_neurocheck = "Yes"
+    else:
+        ccc_neuro = 0
+        ccc_neurocheck = "No"
+    if (int(session['fluf']) >= 2 and int(session['flus']) >= 2) or (
+            int(session['smellf']) >= 2 and int(session['smells']) >= 2):
+        ccc_immune = 1
+        ccc_immunecheck = "Yes"
+    else:
+        ccc_immune = 0
+        ccc_immunecheck = "No"
+    ccc_poly = np.sum([ccc_auto, ccc_neuro, ccc_immune])
+    # most of the symptoms are required, but there is one polythetic criteria, shown here by ccc_poly
+    if np.sum([ccc_fatigue, ccc_reduction, ccc_pem, ccc_sleep, ccc_pain, ccc_cog]) >= 6 and ccc_poly >= 2:
+        ccc_dx = "Met"
+        ccc_msg = "Your responses suggest that you meet the Canadian Consensus Criteria for ME/CFS. " \
+                  "To improve the accuracy of your assessment with more questions continue to the next section."
+    else:
+        ccc_dx = "Not met"
+        ccc_msg = "Your responses do not meet the Canadian Consensus Criteria for ME/CFS."
+
+    # categories = [*feature_list, feature_list[0]]
+    categories = ['Fatigue', 'PEM', 'Sleep', 'Cognitive Impairment', 'Pain', 'Gastro Problems',
+                  'Orthostatic Intolerance', 'Circulatory Problems', 'Immune System', 'Neuroendocrine Problems']
+
+    # converts scores to 100pt scale
+    user_scores = np.multiply(user_scores, 25).tolist()
+    cfsdomains = np.multiply(cfsdomains, 25).tolist()
+
+    # diagnostic message ccc OR iom
+    dx_met = False
+    if ccc_dx == "Met" or iomdxcheck == "Met":
+        short_form_message = "Based on your responses there is a chance you might have MECFS. <br> Please continue to the next section for a more accurate assessment."
+        dx_met = True
+    else:
+        short_form_message = "Based on your responses it does not appear you have MECFS."
+
+    # Creates a figure using the plotly library, which can be dynamically embedded in the HTML page
+    fig = go.Figure(
+        data=[
+            go.Bar(y=user_scores, x=categories, name="Your scores"),
+            go.Bar(y=cfsdomains, x=categories, name="Average ME/CFS scores")],
+        layout=go.Layout(
+            title=go.layout.Title(text='Your scores compared with our dataset of <br>'
+                                       'over 2,400 participants with ME/CFS', x=0.5),
+            showlegend=True, legend=dict(
+                orientation="h",
+                yanchor="bottom",
+                y=1.02,
+                xanchor="right",
+                x=1)))
+    fig.update_layout(yaxis_title='Averaged Frequency and Severity Scores',
+                      xaxis_title='Symptom Domains')
+    fig.update_yaxes(range=[0, 100], dtick=25)
+    # This converts to figure fig to a JSON object so it can be dynamically rendered with javascript on the page
+    graphJSON = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
+
+    return render_template("results/graph2.html", graphJSON=graphJSON, ccc_msg=ccc_msg, ccc_fatiguecheck=ccc_fatiguecheck,
+                           ccc_pemcheck=ccc_pemcheck, ccc_paincheck=ccc_paincheck, ccc_sleepcheck=ccc_sleepcheck,
+                           ccc_cogcheck=ccc_cogcheck, ccc_autocheck=ccc_autocheck, ccc_immunecheck=ccc_immunecheck,
+                           ccc_neurocheck=ccc_neurocheck, ccc_dx=ccc_dx, ccc_reductioncheck=ccc_reductioncheck, ccc_poly=ccc_poly,
+                           iomfatiguecheck=iomfatiguecheck, iomreductioncheck=iomreductioncheck,
+                           iompemcheck=iompemcheck, iomdxcheck=iomdxcheck, iom_msg=iom_msg,
+                           iomsleepcheck=iomsleepcheck, iomcogcheck=iomcogcheck, iomorthocheck=iomorthocheck,
+                           short_form_message=short_form_message,dx_met=dx_met
+                           )

--- a/utils/short_form_utils.py
+++ b/utils/short_form_utils.py
@@ -4,6 +4,11 @@ import plotly.graph_objects as go
 import json
 import plotly.utils
 
+# short form questions:
+# 'fatigue13c', 'soreness15c', 'minimum17c', 'unrefreshed19c',
+# 'musclepain25c', 'bloating29c', 'remember36c', 'difficulty37c',
+# 'bowel46c', 'unsteady48c', 'limbs56c', 'hot58c', 'flu65c','smells66c'
+
 def short_form_diagnose():
     import domainScores as ds
 
@@ -23,17 +28,8 @@ def short_form_diagnose():
     user_scores = [fatiguescore, pemscore, sleepscore, cogscore, painscore, gastroscore, orthoscore, circscore,
                    immunescore, neuroenscore]
 
-    shortform_items = ['fatigue13c', 'soreness15c', 'minimum17c', 'unrefreshed19c',
-                       'musclepain25c', 'bloating29c', 'remember36c', 'difficulty37c',
-                       'bowel46c', 'unsteady48c', 'limbs56c', 'hot58c', 'flu65c',
-                       'smells66c']
-
     df = ds.sdf
-
     mecfs = df[(df['dx'] == 1)]
-    controls = df[(df['dx'] != 1)]
-
-
     cfsdomains = np.mean(mecfs.iloc[:, 110:120], axis=0)
 
     # This assesses the IOM Criteria

--- a/website/screener_views.py
+++ b/website/screener_views.py
@@ -1,8 +1,5 @@
 from flask import Blueprint, render_template, session, request, redirect, url_for
-import pandas as pd
-import json
-import plotly.graph_objects as go
-import plotly.utils
+import utils.screener_utils as screener_utils
 # used for /scores which is currently not in use - PC 7/21/23
 # import numpy as np
 
@@ -120,71 +117,7 @@ def page4():
 
 @screener_views.route('/screener_dx')
 def graph():
-    # we *25 to scale 4pt scale to 100 pt scale
-    fatiguescore = session['fatiguescore'] * 25
-    pemscore = session['pemscore'] * 25
-    sleepscore = session['sleepscore'] * 25
-    cogscore = session['cogscore'] * 25
-
-    df = pd.read_csv('MECFS COMPOSITE DATA.csv')
-    responses = [fatiguescore, pemscore, sleepscore, cogscore]
-    iomfatiguecheck = "No"
-    iompemcheck = "No"
-    iomsleepcheck = "No"
-    iomcogcheck = "No"
-    dx_met = False
-
-    if session['fatiguescoref'] >= 2 and session['fatiguescores'] >= 2:
-        iomfatiguecheck = "Yes"
-    if session['minexf'] >= 2 and session['minexs'] >= 2:
-        iompemcheck = "Yes"
-    if session['sleepf'] >= 2 and session['sleeps'] >= 2:
-        iomsleepcheck = "Yes"
-    if session['rememberf'] >= 2 and session['remembers'] >= 2:
-        iomcogcheck = "Yes"
-
-    if iomfatiguecheck == "Yes" or iompemcheck == "Yes" or iomsleepcheck == "Yes" or iomcogcheck == "Yes":
-        screen_message = 'Based on your responses there is a chance you might have MECFS. <br> Please continue to the next section for a more accurate assessment.'
-        dx_met = True
-    else:
-        screen_message = "Based on your responses it does not appear you have MECFS."
-
-    composite_scores = responses
-    categories = ['Fatigue', 'Post-exertional malaise', 'Sleep problems',
-                  'Cognitive problems']
-
-    select_list = ['fatigue13c', (session['pemname'] + 'c'),
-                   (session['cogname'] + 'c'), (session['sleepname'] + 'c'), 'dx']
-    df = df[select_list]
-    colors = ['#89889E' if score < 50 else '#56A8A0' for score in composite_scores]
-    
-    # composite f/s score graph
-    fig = go.Figure(
-        data=[
-            go.Bar(y=composite_scores, x=categories, name="Your scores", marker=dict(color=colors))],
-        layout=go.Layout(
-            title=go.layout.Title(text='Your Summary Score', x=0.5),
-            showlegend=True, 
-            legend=dict(
-                orientation="h",
-                yanchor="bottom",
-                y=1.02,
-                xanchor="right",
-                x=1
-            ),
-            autosize=True
-        )
-    )
-    fig.update_layout(
-        yaxis_title='Combined Frequency and Severity Scores',
-        xaxis_title='Symptom Domains'
-    )
-    fig.update_yaxes(range=[0, 100], dtick=25)
-    graphJSON = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
-    return render_template("results/graph.html",
-                           graphJSON = graphJSON, 
-                           screen_message = screen_message,
-                           dx_met = dx_met)
+    return screener_utils.screener_diagnose()
 
 # not currently in use since we disabled users - PC 7/21/23
 # @screener_views.route('/scores')

--- a/website/screener_views.py
+++ b/website/screener_views.py
@@ -21,7 +21,6 @@ def home():
 # First symptom question
 @screener_views.route('/fatigue', methods=['post', 'get'])
 def page1():
-
     session['pagenum'] = 1
     if request.method == "POST":
         selected_radio = request.form.get('fatigue')
@@ -33,7 +32,6 @@ def page1():
             session['fatiguescores'] = int(fatiguescores)
             session['fatiguescore'] = (session['fatiguescoref'] + session['fatiguescores']) / 2
             session['pagenum'] += 1
-
             return redirect(url_for("screener_views.page2"))
         else:
             return render_template("screener/page1.html", pagenum=session['pagenum'], message=message,
@@ -67,7 +65,6 @@ def page2():
 @screener_views.route('/unrefreshed', methods=['post', 'get'])
 def page3():
     global sleepname
-
     if request.method == "POST":
         sleepf = request.form.get("sleepf")
         sleeps = request.form.get("sleeps")
@@ -75,15 +72,12 @@ def page3():
             session["sleepf"] = int(sleepf)
             session["sleeps"] = int(sleeps)
             session['pagenum'] += 1
-
             if int(session["sleepf"]) >= 0 and int(session["sleeps"]) >= 0:
                 session['sleepscoref'] = int(sleepf)
                 session['sleepscores'] = int(sleeps)
                 session['sleepscore'] = (int(session['sleepf']) + int(session['sleeps'])) / 2
                 session["sleepname"] = 'unrefreshed19'
-
                 return redirect(url_for("screener_views.page4"))
-
         else:
             return render_template("screener/page3.html", pagenum=session['pagenum'], message=message,
                                    sleepf=sleepf, sleeps=sleeps)
@@ -93,7 +87,6 @@ def page3():
 @screener_views.route('/remember', methods=['post', 'get'])
 def page4():
     global cogname
-
     if request.method == "POST":
         rememberf = request.form.get("rememberf")
         remembers = request.form.get("remembers")
@@ -101,14 +94,11 @@ def page4():
             session["rememberf"] = int(rememberf)
             session["remembers"] = int(remembers)
             session['pagenum'] += 1
-
             session['cogscoref'] = int(rememberf)
             session['cogscores'] = int(remembers)
             session["cogname"] = 'remember36'
             session['cogscore'] = (int(session['rememberf']) + int(session['remembers'])) / 2
-
             return redirect(url_for('screener_views.graph'))
-
         else:
             return render_template("screener/page4.html", pagenum=session['pagenum'], message=message,
                                    rememberf=rememberf, remembers=remembers)

--- a/website/short_form.py
+++ b/website/short_form.py
@@ -1,12 +1,7 @@
 from flask import Blueprint, render_template, session, request, redirect, url_for
-import pandas as pd
-import json
-import plotly.graph_objects as go
-import plotly.utils
-import numpy as np
+import utils.short_form_utils as short_form_utils
 
 short_form = Blueprint('short_form', __name__)
-
 
 message = "Please enter a response for both frequency and severity before continuing"
 
@@ -28,8 +23,6 @@ def expem1():
                 pemname = 'soreness15'
 
                 return redirect(url_for("short_form.excog1"))
-
-
         else:
             return render_template("short_form/expem1.html", pagenum=session['pagenum'], message=message)
     return render_template("short_form/expem1.html", pagenum=session['pagenum'], message='')
@@ -191,190 +184,6 @@ def reduction():
             return render_template("short_form/reduction.html", message=msg_reduction, pagenum=session['pagenum'])
     return render_template("short_form/reduction.html", message='', pagenum=session['pagenum'])
 
-
 @short_form.route('/short_form_dx', methods=['post', 'get'])
 def graph2():
-    import domainScores as ds
-
-    fatiguescore = (int(session["fatiguescoref"]) + int(session["fatiguescores"])) / 2
-    pemscore = (int(session["minexf"]) + int(session["minexs"]) + int(session['soref']) + int(session['sores'])) / 4
-    sleepscore = (int(session["sleepf"]) + int(session["sleeps"])) / 2
-    cogscore = (int(session["rememberf"]) + int(session["remembers"]) + int(session['attentionf']) +
-                int(session['attentions'])) / 4
-    painscore = (int(session['musclef']) + int(session['muscles'])) / 2
-    gastroscore = (int(session['bloatf']) + int(session['bloats']) + int(session['bowelf']) +
-                   int(session['bowels'])) / 4
-    orthoscore = (int(session['unsteadyf']) + int(session['unsteadys'])) / 2
-    circscore = (int(session['limbsf']) + int(session['limbss']) + int(session['hotf']) + int(session['hots'])) / 4
-    immunescore = (int(session['fluf']) + int(session['flus'])) / 2
-    neuroenscore = (int(session['smellf']) + int(session['smells'])) / 2
-
-    user_scores = [fatiguescore, pemscore, sleepscore, cogscore, painscore, gastroscore, orthoscore, circscore,
-                   immunescore, neuroenscore]
-
-    shortform_items = ['fatigue13c', 'soreness15c', 'minimum17c', 'unrefreshed19c',
-                       'musclepain25c', 'bloating29c', 'remember36c', 'difficulty37c',
-                       'bowel46c', 'unsteady48c', 'limbs56c', 'hot58c', 'flu65c',
-                       'smells66c']
-
-    df = ds.sdf
-
-    mecfs = df[(df['dx'] == 1)]
-    controls = df[(df['dx'] != 1)]
-
-
-    cfsdomains = np.mean(mecfs.iloc[:, 110:120], axis=0)
-
-    # This assesses the IOM Criteria
-    responses = [fatiguescore, pemscore, sleepscore, cogscore]
-    iomfatiguecheck = "No"
-    iomreductioncheck = "No"
-    iompemcheck = "No"
-    iomsleepcheck = "No"
-    iomcogcheck = "No"
-    iomorthocheck = "No"
-
-    if int(session['fatiguescoref']) >= 2 and int(session['fatiguescores']) >= 2:
-        iomfatiguecheck = "Yes"
-    if int(session['reduction']) == 1:
-        iomreductioncheck = "Yes"
-    if (int(session['minexf']) >= 2 and int(session['minexs'] >= 2) or (
-            int(session['soref']) >= 2 and int(session['sores']) >= 2)):
-        iompemcheck = "Yes"
-    if int(session['sleepf']) >= 2 and int(session['sleeps']) >= 2:
-        iomsleepcheck = "Yes"
-    if (int(session['rememberf']) >= 2 and int(session['remembers']) >= 2 ) or (
-            int(session['attentionf']) >= 2 and int(session['attentions']) >= 2):
-        iomcogcheck = "Yes"
-    if int(session['unsteadyf']) >= 2 and int(session['unsteadys']) >= 2:
-        iomorthocheck = "Yes"
-
-    if iomfatiguecheck == "Yes" and iomreductioncheck == "Yes" and iompemcheck == "Yes" and iomsleepcheck == "Yes" and (iomcogcheck == "Yes" or iomorthocheck == "Yes"):
-        iom_msg = "Your responses suggest you meet the IOM Criteria for ME/CFS. To improve the accuracy" \
-                  " of your assessment with more questions continue to the next section."
-        iomdxcheck = "Met"
-
-    else:
-        iom_msg = "Your responses do not meet the IOM Criteria for ME/CFS."
-        iomdxcheck = "Not met"
-
-    # This assesses the Canadian Consensus Criteria, one of the three major case definitions we use
-
-    ccc_dx = False
-
-    if int(session['fatiguescoref']) >= 2 and int(session['fatiguescores']) >= 2:
-        ccc_fatigue = 1
-        ccc_fatiguecheck = "Yes"
-    else:
-        ccc_fatigue = 0
-        ccc_fatiguecheck = "No"
-    if int(session['reduction']) == 1:
-        ccc_reduction = 1
-        ccc_reductioncheck = "Yes"
-    else:
-        ccc_reduction = 0
-        ccc_reductioncheck = "No"
-    if int(session['musclef']) >= 2 and int(session['muscles']) >= 2:
-        ccc_pain = 1
-        ccc_paincheck = "Yes"
-    else:
-        ccc_pain = 0
-        ccc_paincheck = "No"
-    if int(session['sleepf']) >= 2 and int(session['sleeps']) >= 2:
-        ccc_sleep = 1
-        ccc_sleepcheck = "Yes"
-    else:
-        ccc_sleep = 0
-        ccc_sleepcheck = "No"
-    if (int(session['minexf']) >= 2 and int(session['minexs']) >= 2) or (
-            int(session['soref']) >= 2 and int(session['sores']) >= 2):
-        ccc_pem = 1
-        ccc_pemcheck = "Yes"
-    else:
-        ccc_pem = 0
-        ccc_pemcheck = "No"
-    if (int(session['rememberf']) >= 2 and int(session['remembers']) >= 2) or (
-            int(session['attentionf']) >= 2 and int(session['attentions']) >= 2):
-        ccc_cog = 1
-        ccc_cogcheck = "Yes"
-    else:
-        ccc_cog = 0
-        ccc_cogcheck = "No"
-
-    if (int(session['unsteadyf']) >= 2 and int(session['unsteadys']) >= 2) or (
-            int(session['bowelf']) >= 2 and int(session['bowels']) >= 2) or (
-            int(session['bloatf']) >= 2 and int(session['bloats']) >= 2):
-        ccc_auto = 1
-        ccc_autocheck = "Yes"
-    else:
-        ccc_auto = 0
-        ccc_autocheck = "No"
-    if (int(session['limbsf']) >= 2 and int(session['limbss']) >= 2) or (
-            int(session['hotf']) >= 2 and int(session['hots']) >= 2):
-        ccc_neuro = 1
-        ccc_neurocheck = "Yes"
-    else:
-        ccc_neuro = 0
-        ccc_neurocheck = "No"
-    if (int(session['fluf']) >= 2 and int(session['flus']) >= 2) or (
-            int(session['smellf']) >= 2 and int(session['smells']) >= 2):
-        ccc_immune = 1
-        ccc_immunecheck = "Yes"
-    else:
-        ccc_immune = 0
-        ccc_immunecheck = "No"
-    ccc_poly = np.sum([ccc_auto, ccc_neuro, ccc_immune])
-    # most of the symptoms are required, but there is one polythetic criteria, shown here by ccc_poly
-    if np.sum([ccc_fatigue, ccc_reduction, ccc_pem, ccc_sleep, ccc_pain, ccc_cog]) >= 6 and ccc_poly >= 2:
-        ccc_dx = "Met"
-        ccc_msg = "Your responses suggest that you meet the Canadian Consensus Criteria for ME/CFS. " \
-                  "To improve the accuracy of your assessment with more questions continue to the next section."
-    else:
-        ccc_dx = "Not met"
-        ccc_msg = "Your responses do not meet the Canadian Consensus Criteria for ME/CFS."
-
-    # categories = [*feature_list, feature_list[0]]
-    categories = ['Fatigue', 'PEM', 'Sleep', 'Cognitive Impairment', 'Pain', 'Gastro Problems',
-                  'Orthostatic Intolerance', 'Circulatory Problems', 'Immune System', 'Neuroendocrine Problems']
-
-    # converts scores to 100pt scale
-    user_scores = np.multiply(user_scores, 25).tolist()
-    cfsdomains = np.multiply(cfsdomains, 25).tolist()
-
-    # diagnostic message ccc OR iom
-    dx_met = False
-    if ccc_dx == "Met" or iomdxcheck == "Met":
-        short_form_message = "Based on your responses there is a chance you might have MECFS. <br> Please continue to the next section for a more accurate assessment."
-        dx_met = True
-    else:
-        short_form_message = "Based on your responses it does not appear you have MECFS."
-
-    # Creates a figure using the plotly library, which can be dynamically embedded in the HTML page
-    fig = go.Figure(
-        data=[
-            go.Bar(y=user_scores, x=categories, name="Your scores"),
-            go.Bar(y=cfsdomains, x=categories, name="Average ME/CFS scores")],
-        layout=go.Layout(
-            title=go.layout.Title(text='Your scores compared with our dataset of <br>'
-                                       'over 2,400 participants with ME/CFS', x=0.5),
-            showlegend=True, legend=dict(
-                orientation="h",
-                yanchor="bottom",
-                y=1.02,
-                xanchor="right",
-                x=1)))
-    fig.update_layout(yaxis_title='Averaged Frequency and Severity Scores',
-                      xaxis_title='Symptom Domains')
-    fig.update_yaxes(range=[0, 100], dtick=25)
-    # This converts to figure fig to a JSON object so it can be dynamically rendered with javascript on the page
-    graphJSON = json.dumps(fig, cls=plotly.utils.PlotlyJSONEncoder)
-
-    return render_template("results/graph2.html", graphJSON=graphJSON, ccc_msg=ccc_msg, ccc_fatiguecheck=ccc_fatiguecheck,
-                           ccc_pemcheck=ccc_pemcheck, ccc_paincheck=ccc_paincheck, ccc_sleepcheck=ccc_sleepcheck,
-                           ccc_cogcheck=ccc_cogcheck, ccc_autocheck=ccc_autocheck, ccc_immunecheck=ccc_immunecheck,
-                           ccc_neurocheck=ccc_neurocheck, ccc_dx=ccc_dx, ccc_reductioncheck=ccc_reductioncheck, ccc_poly=ccc_poly,
-                           iomfatiguecheck=iomfatiguecheck, iomreductioncheck=iomreductioncheck,
-                           iompemcheck=iompemcheck, iomdxcheck=iomdxcheck, iom_msg=iom_msg,
-                           iomsleepcheck=iomsleepcheck, iomcogcheck=iomcogcheck, iomorthocheck=iomorthocheck,
-                           short_form_message=short_form_message,dx_met=dx_met
-                           )
+    return short_form_utils.short_form_diagnose()

--- a/website/short_form.py
+++ b/website/short_form.py
@@ -15,13 +15,11 @@ def expem1():
             session["soref"] = soref
             session["sores"] = sores
             session['pagenum'] += 1
-
             if int(session["soref"]) >= 0 and int(session["sores"]) >= 0:
                 session['pemscoref'] = session['soref']
                 session['pemscores'] = session['sores']
                 session['pemscore'] = (int(session['soref']) + int(session['sores'])) / 2
                 pemname = 'soreness15'
-
                 return redirect(url_for("short_form.excog1"))
         else:
             return render_template("short_form/expem1.html", pagenum=session['pagenum'], message=message)
@@ -92,7 +90,6 @@ def bowel():
         else:
             return render_template("short_form/bowel.html", message=message, pagenum=session['pagenum'])
     return render_template("short_form/bowel.html", message='', pagenum=session['pagenum'])
-
 
 @short_form.route('/unsteady', methods=['post', 'get'])
 def unsteady():

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -278,7 +278,7 @@ h3 {
 
 h3.ariel {
   font-family: "Arial", Helvetica, sans-serif;
-  margin: 21px auto;
+  margin: 10px auto 10px auto;
   text-align: center;
 }
 

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -238,9 +238,9 @@ a {
 button {
   display: flex;
   align-items: center;
+  justify-content: center;
+  max-width: min-content;
   font-size: 1.3em;
-  margin: 10px 25px;
-  max-width: 100%;
   max-height: 88px;
   letter-spacing: 0px;
   padding: 25px;

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -252,7 +252,7 @@ button {
     inset 0 -2px 6px rgba(0, 0, 0, 0.4);
 }
 
-button:hover {
+button:hover:not(.disabled) {
   background-color: #f3cfc6;
 }
 

--- a/website/static/css/main.css
+++ b/website/static/css/main.css
@@ -238,12 +238,12 @@ a {
 button {
   display: flex;
   align-items: center;
-  font-size: 1em;
+  font-size: 1.3em;
   margin: 10px 25px;
   max-width: 100%;
   max-height: 88px;
   letter-spacing: 0px;
-  padding: 30px;
+  padding: 25px;
   border-top-right-radius: 5px;
   border-bottom-right-radius: 5px;
   border-top-left-radius: 5px;
@@ -271,7 +271,6 @@ h2 {
 
 h3 {
   font-size: 1.7em;
-  font-weight: 100;
   margin-top: 30px;
   text-align: center;
 }
@@ -324,14 +323,6 @@ select {
   width: 70%;
   height: auto;
   border: thin #c0c0c0 solid;
-}
-
-.button {
-  bottom: 0px;
-  border-top-right-radius: 8px;
-  border-bottom-right-radius: 8px;
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px;
 }
 
 /* The contaner must be positioned relative: */
@@ -623,6 +614,12 @@ footer {
 
   .disclaimer {
     display: none;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  button {
+    padding: 30px;
   }
 }
 

--- a/website/static/css/questions.css
+++ b/website/static/css/questions.css
@@ -24,6 +24,15 @@ form.single-question {
   padding: 0 20% 0 20%;
 }
 
+form.single-question .instructions {
+  margin-bottom: 20px;
+}
+
+form.single-question .question-title {
+  height: 5em;
+  margin: 25px 0 20px 0;
+}
+
 .question-header {
   grid-column: 1 / 3;
   grid-row: 1;
@@ -51,7 +60,7 @@ div#right {
   grid-row: 3;
   grid-column: 1 / 3;
   display: grid;
-  justify-content: space-around;
+  justify-content: center;
   justify-items: center;
   margin-bottom: 30px;
 }
@@ -138,11 +147,14 @@ li > label {
 }
 
 .question-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
   font-weight: 500;
   background: rgb(255,255,255);
   background: radial-gradient(circle, rgba(255,255,255,85%) 25%, rgba(255,255,255,0) 100%);
 }
-
 
 .instructions {
   font-weight: 500;
@@ -155,6 +167,7 @@ li > label {
   margin: 30px auto 0;
   max-width: 60vw;
   font-size: 1.2em;
+  border: 1px solid black;
 }
 
 .error-message {
@@ -230,6 +243,11 @@ li > label {
   form.single-question {
     padding: 0 5px 0 5px;
     grid-template-rows: auto;
+  }
+
+  form.single-question .question-title {
+    height: 6em;
+    margin: 25px 0 25px 0;
   }
 
   .radio-button-list {

--- a/website/static/css/questions.css
+++ b/website/static/css/questions.css
@@ -42,7 +42,7 @@ div#right {
   grid-row: 2;
 }
 
-/* we use the class instead of attribute to allow the error message to fire */
+/* we use the class instead of attribute on disabled buttons to allow the error message to fire when clicked*/
 .disabled {
   opacity: .5;
 }
@@ -50,9 +50,18 @@ div#right {
 .question-navigation {
   grid-row: 3;
   grid-column: 1 / 3;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  display: grid;
+  justify-content: space-around;
+  justify-items: center;
+  margin-bottom: 30px;
+}
+
+.question-navigation .back-button {
+  grid-row: 2;
+}
+
+.question-navigation .next-question-button {
+  grid-row: 2;
 }
 
 ol.radio-button-list > li {
@@ -148,13 +157,20 @@ li > label {
   font-size: 1.2em;
 }
 
-/* error text */
-.typed {
+.error-message {
+  grid-row: 1;
+  grid-column: 1/ 3;
+  font-style: italic;
   text-decoration: underline red;
   text-underline-offset: 5px;
-  height: 1em;
+  height: min-content;
   text-align: center;
-  margin: 0 0 2em 0;
+  margin: 0 0 1.5em 0;
+  font-size: 1em;
+}
+
+.hidden {
+  visibility: hidden;
 }
 
 @media only screen and (max-width: 1279px) {
@@ -168,12 +184,16 @@ li > label {
 }
 
 @media only screen and (max-width: 899px) {
+  .error-message {
+    margin: 0 0 .8em 0;
+  }
+
   .instructions {
     max-width: 80vw;
   }
 
   form.two-question {
-    padding: 0 5% 0 5%;
+    padding: 0 4% 0 4%;
     grid-template-columns: none;
     grid-template-rows: auto;
   }
@@ -190,6 +210,10 @@ li > label {
   div#right {
     grid-column: 1;
     grid-row: 3;
+  }
+
+  div#right fieldset {
+    margin-bottom: 10px;
   }
   
   .question-navigation {
@@ -231,9 +255,5 @@ li > label {
 
   .radio-button-list {
     margin-bottom: 0
-  }
-
-  .typed {
-    margin: 0 0 1.5em 0;
   }
 }

--- a/website/static/css/results.css
+++ b/website/static/css/results.css
@@ -27,11 +27,6 @@
   background-color: #F3CFC6;
 }
 
-.print-button {
-  display: block;
-  margin-top: 25px;
-}
-
 .case-results {
   background: white;
   width: 55%;
@@ -94,11 +89,26 @@
 }
 
 .result-navigation {
-  grid-row: 3;
-  grid-column: 1 / 3;
-  display: flex;
+  display: grid;
+  justify-items: center;
   justify-content: center;
-  align-items: center;
+  max-width: 100vw;
+}
+
+.result-navigation .back-button {
+  grid-column: 1 / 2;
+  grid-row: 1;
+}
+
+.result-navigation .continue-button {
+  grid-column: 2 / 3;
+  grid-row: 1;
+}
+
+.result-navigation .print-button {
+  grid-row: 2;
+  grid-column: 1/3;
+  padding: 20px;
 }
 
 .symptom-list {

--- a/website/static/css/results.css
+++ b/website/static/css/results.css
@@ -6,6 +6,11 @@
   background-color: #F3CFC6;
   border-top: 1px solid black;
   border-bottom: 1px solid black;
+  font-size: 1.1em;
+}
+
+.diagnostic-message.screener {
+  font-weight: 400;
 }
 
 .continue-message {
@@ -245,7 +250,7 @@
 }
 
 @media screen and (max-width: 1280px) {
-  .chart-center {
+  .chart-center.screener {
     zoom: .80;
   }
 }

--- a/website/static/css/results.css
+++ b/website/static/css/results.css
@@ -11,10 +11,6 @@
 .continue-message {
   text-align: center;
   background-color: #bfffb7;
-  /* border-top-right-radius: 8px;
-  border-bottom-right-radius: 8px;
-  border-top-left-radius: 8px;
-  border-bottom-left-radius: 8px; */
   border-top: 1px solid black;
   border-bottom: 1px solid black;
   margin: 10px auto 10px;
@@ -246,6 +242,12 @@
 
 .two-buttons button {
   margin: 10px 10px 0 0;
+}
+
+@media screen and (max-width: 1280px) {
+  .chart-center {
+    zoom: .80;
+  }
 }
 
 @media screen and (max-width: 1024px) {

--- a/website/static/css/results.css
+++ b/website/static/css/results.css
@@ -18,7 +18,7 @@
   background-color: #bfffb7;
   border-top: 1px solid black;
   border-bottom: 1px solid black;
-  margin: 10px auto 10px;
+  margin: 10px auto 20px;
   padding: 5px 5px 5px 5px;
   font-size: 1.1em;
 }
@@ -99,11 +99,15 @@
 .result-navigation .back-button {
   grid-column: 1 / 2;
   grid-row: 1;
+  margin: 0 10px 20px 0;
+  padding-left: 43px;
+  padding-right: 43px;
 }
 
 .result-navigation .continue-button {
   grid-column: 2 / 3;
   grid-row: 1;
+  margin: 0 0 20px 10px;
 }
 
 .result-navigation .print-button {
@@ -250,16 +254,6 @@
   height: auto;
 }
 
-.two-buttons {
-  white-space: nowrap;
-  display: flex;
-  justify-content: center;
-}
-
-.two-buttons button {
-  margin: 10px 10px 0 0;
-}
-
 @media screen and (max-width: 1280px) {
   .chart-center.screener {
     zoom: .80;
@@ -280,6 +274,14 @@
   .chart-center {
     zoom: .45;
     width: 90%;
+  }
+  
+  .result-navigation .back-button {
+    padding: 30px;
+  }
+
+  .result-navigation .continue-button {
+    padding: 25px;
   }
 }
 

--- a/website/static/css/results.css
+++ b/website/static/css/results.css
@@ -1,5 +1,5 @@
 .diagnostic-message {
-  font-weight: bold;
+  /* font-weight: bold; */
   padding: 10px;
   margin-bottom: 10px;
   text-align: center;
@@ -38,13 +38,14 @@
 
 .case-results-title {
   margin: 5px 0 5px 0;
+  text-align: center;
 }
 
 .case-results-diagnosis {
   text-align: left;
   border: 1px solid black;
   border-bottom: 0;
-  font-weight: bold;
+  /* font-weight: bold; */
   background-color: #F3CFC6;
   padding: 10px 0 10px 0;
 }

--- a/website/templates/dsq/viral.html
+++ b/website/templates/dsq/viral.html
@@ -2,17 +2,15 @@
 {% block content %}
 <form method="post" class="single-question">
   <div class="question-header">
-    <p class="instructions">
-      <i>For the following question, please select the choice that best fits
-        your experience.
-      </i>
-    </p>
     <h3 class="question-title">Do you experience frequent viral infections with prolonged
       recovery periods?
     </h3>
   </div>
   <div class="single-question-container">
     <fieldset>
+      <legend>
+        Please select the choice that best fits your experience:
+      </legend>
       <ol class="radio-button-list">
         <li>
           <input type="radio" id="f1" name="viral" value="1" />

--- a/website/templates/dsq/viral.html
+++ b/website/templates/dsq/viral.html
@@ -25,6 +25,7 @@
       </ol>
     </fieldset>
   </div>
+<!-- <form> element closes in /_f_s_question template -->
 {% set single_question = True %}
 {% set next_button_text = "Next" %}
 {% set meter_id = "meter3span" %}

--- a/website/templates/partials/_f_s_question.html
+++ b/website/templates/partials/_f_s_question.html
@@ -73,15 +73,22 @@
     </fieldset>
   </div>
 {% endif %}
-  <div class="question-navigation">
-    <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">Back</button>
-    <button class="next-question-button disabled" type="submit" name="result" value="result">{{ next_button_text }}</button>
+<div class="question-navigation">
+{% if message %}
+    <p class="error-message">
+{% else %}
+    <p class="error-message hidden">
+{% endif %}
+      Please enter a response for both frequency and severity before continuing
+    </p>
+    <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
+      Back
+    </button>
+    <button class="next-question-button disabled" type="submit" name="result" value="result">
+      {{ next_button_text }}
+    </button>
   </div>
 </form>
-
-<div class="container">
-  <p class="typed"><i>{{ message }} </i></p>
-</div>
 
 <div class="meter">
   <span id={{ meter_id }} style="{{ meter_style }}"></span>

--- a/website/templates/partials/_f_s_question.html
+++ b/website/templates/partials/_f_s_question.html
@@ -4,7 +4,7 @@
 {% if instructions %}
     <p class="instructions">
       <i>
-        You will now be presented a series of symptoms. For each one please rate how often (<b>frequency</b>) and how intensely (<b>severity</b>) you have experienced this symptom over the past 6 months.
+        You will now be presented a series of symptoms.<br>For each one please rate how often (<b>frequency</b>) and how intensely (<b>severity</b>) you have experienced this symptom over the past 6 months.
       </i>
     </p>
 {% endif %}

--- a/website/templates/results/graph.html
+++ b/website/templates/results/graph.html
@@ -19,17 +19,26 @@
 </div>
 
 {% if dx_met %}
-<div class="continue-message">Continue to answer more questions for a more accurate assessment...</div>
-{% else %}
-<div class="continue-message red">Though it is not suggested based on your assessment, you may continue to answer more questions.</div>
-{% endif %}
-
+<div class="continue-message">Based on your responses, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
 <div class="result-navigation">
-  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">Back</button>
+  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
+    Back
+  </button>
   <button onclick="window.location.href='{{ url_for('short_form.expem1') }}'">
     Continue
   </button>
 </div>
+{% else %}
+<div class="continue-message red">You do not have ME/CFS.</div>
+<div class="result-navigation">
+  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
+    Back
+  </button>
+  <button onclick="window.location.href='{{ url_for('screener_views.home') }}'">
+    Home
+  </button>
+</div>
+{% endif %}
 
 <p class="disclaimer"><i>Disclaimer: This screener is not meant to provide medical diagnoses. Please consult with your physician if you believe you may be suffering from ME/CFS.</i></p>
 {% endblock %}

--- a/website/templates/results/graph.html
+++ b/website/templates/results/graph.html
@@ -21,24 +21,23 @@
 {% if dx_met %}
 <div class="continue-message">Based on your responses to this screener, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
 <div class="result-navigation">
-  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
-    Back
-  </button>
-  <button onclick="window.location.href='{{ url_for('short_form.expem1') }}'">
+  <button class="continue-button" onclick="window.location.href='{{ url_for('short_form.expem1') }}'">
     Continue
   </button>
-</div>
 {% else %}
 <div class="continue-message red">Based on your responses to this screener, it is unlikely you have ME/CFS.</div>
 <div class="result-navigation">
-  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
-    Back
-  </button>
-  <button onclick="window.location.href='{{ url_for('screener_views.home') }}'">
+  <button class="continue-button" onclick="window.location.href='{{ url_for('screener_views.home') }}'">
     Home
   </button>
-</div>
 {% endif %}
+  <button class="back-button" onClick="javascript:window.location.href='{{previous_page(request.path)}}'" type="button">
+    Back
+  </button>
+  <button class="print-button" onclick="window.print();return false;">
+    Print/Save PDF
+  </button>
+</div>
 
 <p class="disclaimer"><i>Disclaimer: This screener is not meant to provide medical diagnoses. Please consult with your physician if you believe you may be suffering from ME/CFS.</i></p>
 {% endblock %}

--- a/website/templates/results/graph.html
+++ b/website/templates/results/graph.html
@@ -5,9 +5,9 @@
 <h3 class="ariel">Screener Results</h3>
 
 <div class="results">
-  <div class="diagnostic-message">{{ screen_message|safe }}</div>
+  <div class="diagnostic-message screener">{{ screen_message|safe }}</div>
   <div class="container">
-    <div class="chart-center">
+    <div class="chart-center screener">
       <figure id="chart"></figure>
       <script src='https://cdn.plot.ly/plotly-latest.min.js'></script>
       <script type='text/javascript'>

--- a/website/templates/results/graph.html
+++ b/website/templates/results/graph.html
@@ -19,7 +19,7 @@
 </div>
 
 {% if dx_met %}
-<div class="continue-message">Based on your responses, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
+<div class="continue-message">Based on your responses to this screener, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
 <div class="result-navigation">
   <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
     Back
@@ -29,7 +29,7 @@
   </button>
 </div>
 {% else %}
-<div class="continue-message red">You do not have ME/CFS.</div>
+<div class="continue-message red">Based on your responses to this screener, it is unlikely you have ME/CFS.</div>
 <div class="result-navigation">
   <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">
     Back

--- a/website/templates/results/graph2.html
+++ b/website/templates/results/graph2.html
@@ -98,12 +98,14 @@
 {% endif %}
 
 <div class="result-navigation">
-  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">Back</button>
-  <button onclick="window.print();return false;">
-    Print/Save PDF
+  <button class="back-button" onClick="javascript:window.location.href='{{previous_page(request.path)}}'" type="button">
+    Back
   </button>
-  <button onclick="window.location.href='{{ url_for('viral') }}'">
+  <button class="continue-button" onclick="window.location.href='{{ url_for('viral') }}'">
     Continue
+  </button>
+  <button class="print-button" onclick="window.print();return false;">
+    Print/Save PDF
   </button>
 </div>
 

--- a/website/templates/results/graph2.html
+++ b/website/templates/results/graph2.html
@@ -19,7 +19,7 @@
   </div>
 
   <div class="case-results">
-    <h3 class="case-results-title">Institute of Medicine (IOM) Case Definition</h3>
+    <h4 class="case-results-title">Institute of Medicine (IOM) Case Definition</h4>
     <div class="case-results-diagnosis">{{ iom_msg }}</div>
     <div class="case-results-symptom-header">Case Definition Requirements Met: </div>
     <div class="symptom-list closed" id="iom">
@@ -52,7 +52,7 @@
   </div>
 
   <div class="case-results">
-    <h3 class="case-results-title">Canadian 2003 ME/CFS Case Definition</h3>
+    <h4 class="case-results-title">Canadian 2003 ME/CFS Case Definition</h4>
     <div class="case-results-diagnosis">{{ ccc_msg }}</div>
     <div class="case-results-symptom-header">Case Definition Requirements Met: </div>
     <div class="symptom-list closed" id="ccc">
@@ -92,7 +92,7 @@
 </div>
 
 {% if dx_met %}
-<div class="continue-message">Based on your responses to this screener, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
+<div class="continue-message">Your responses indicate you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
 {% else %}
 <div class="continue-message red">Though it is not suggested based on your assessment, you may continue to answer more questions.</div>
 {% endif %}

--- a/website/templates/results/graph2.html
+++ b/website/templates/results/graph2.html
@@ -92,7 +92,7 @@
 </div>
 
 {% if dx_met %}
-<div class="continue-message">Continue to answer more questions for a more accurate assessment...</div>
+<div class="continue-message">Based on your responses to this screener, you might have ME/CFS.<br> We recommend you click continue to answer additional questions...</div>
 {% else %}
 <div class="continue-message red">Though it is not suggested based on your assessment, you may continue to answer more questions.</div>
 {% endif %}

--- a/website/templates/results/graph3.html
+++ b/website/templates/results/graph3.html
@@ -19,7 +19,7 @@
   </div>
 
   <div class="case-results">
-    <h3 class="case-results-title">Institute of Medicine (IOM) Case Definition</h3>
+    <h4 class="case-results-title">Institute of Medicine (IOM) Case Definition</h4>
     <div class="case-results-diagnosis">{{ iom_msg }}</div>
     <div class="case-results-symptom-header">Case Definition Requirements Met: </div>
     <div class="symptom-list closed" id="iom">
@@ -52,7 +52,7 @@
   </div>
 
   <div class="case-results">
-    <h3 class="case-results-title">Canadian 2003 ME/CFS Case Definition</h3>
+    <h4 class="case-results-title">Canadian 2003 ME/CFS Case Definition</h4>
     <div class="case-results-diagnosis">{{ ccc_msg }}</div>
     <div class="case-results-symptom-header">Case Definition Requirements Met: </div>
     <div class="symptom-list closed" id="ccc">

--- a/website/templates/results/graph3.html
+++ b/website/templates/results/graph3.html
@@ -92,8 +92,13 @@
 </div>
 
 <div class="result-navigation">
-  <button onClick="javascript:window.location.href='{{previous_page(request.path)}}'" class="back-button" type="button">Back</button>
-  <button onclick="window.print();return false;">
+  <button class="back-button" onClick="javascript:window.location.href='{{previous_page(request.path)}}'" type="button">
+    Back
+  </button>
+  <button class="continue-button" onclick="window.location.href='{{ url_for('screener_views.home') }}'">
+    Home
+  </button>
+  <button class="print-button" onclick="window.print();return false;">
     Print/Save PDF
   </button>
 </div>

--- a/website/templates/short_form/reduction.html
+++ b/website/templates/short_form/reduction.html
@@ -2,11 +2,6 @@
 {% block content %}
 <form method="post" class="single-question">
   <div class="question-header">
-    <p class="instructions">
-      <i>For the following question, please select the choice that best fits
-        your experience.
-      </i>
-    </p>
     <h3 class="question-title">Since the onset of your problems with fatigue / energy,
       have your symptoms caused a 50% or greater reduction in your activity
       level?
@@ -14,6 +9,9 @@
   </div>
   <div class="single-question-container">
     <fieldset>
+      <legend>
+        Please select the choice that best fits your experience:
+      </legend>
       <ol class="radio-button-list">
         <li>
           <input type="radio" id="f1" name="reduction" value="1" />
@@ -30,6 +28,7 @@
       </ol>
     </fieldset>
   </div>
+<!-- <form> element closes in /_f_s_question template -->
 {% set single_question = True %}
 {% set next_button_text = "Submit" %}
 {% set meter_id = "meter2span" %}


### PR DESCRIPTION
-Update the prompts on the results page for continuing
-Move assessment logic for screener and short_form into util files
-F/S error message in questions now displays correctly and responsively
-Rearranges back/continue/print buttons to work with moved error message and normalizes style
-For single-question pages removed unnecessary instructions and moved them into the legend for the question